### PR TITLE
Add empty event handlers for installation buttons

### DIFF
--- a/src/components/InstallButtons.tsx
+++ b/src/components/InstallButtons.tsx
@@ -1,6 +1,9 @@
 import * as React from "react";
 
 export interface InstallButtonsProps {
+    packageLink: string;
+    packageName: string;
+    packageVersion: string;
 }
 
 export interface InstallButtonsState {
@@ -13,9 +16,30 @@ export class InstallButtons extends React.Component<InstallButtonsProps, Install
     constructor(props: InstallButtonsProps) {
         super(props);
         this.state = { installed: false, hasUpdate: false};
+
+        this.installPackage = this.installPackage.bind(this);
+        this.updatePackage = this.updatePackage.bind(this);
+        this.uninstallPackage = this.uninstallPackage.bind(this);
+    }
+
+    installPackage() {
+    }
+
+    updatePackage() {
+    }
+
+    uninstallPackage() {
     }
 
     render() {
-        return (<div>Install Buttons</div>);
+        if (!this.state.installed) {
+            return (<div className="InstallButtons" onClick={ this.installPackage }>INSTALL</div>);
+        }
+        else {
+            return (<div>
+                        <div className="InstallButtons" onClick={ this.uninstallPackage }>UNINSTALL</div>
+                        <div  className="InstallButtons" onClick={ this.updatePackage } hidden={!this.state.hasUpdate}>UPDATE</div>
+                    </div>);
+        }
     }
 }

--- a/src/resources/packageManagerStyle.css
+++ b/src/resources/packageManagerStyle.css
@@ -9,6 +9,12 @@
     align-content: stretch;
 }
 
+.InstallButtons {
+    flex-grow: 1;
+    width: 100%;
+    background: cornflowerblue;
+}
+
 .LeftContainer {
     background: cornflowerblue;
 }


### PR DESCRIPTION
This pull request is mainly to add empty event handlers for installation buttons.